### PR TITLE
chore: configure eslint and add scripts

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,49 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2020": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "extends": [
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended",
+    "react-app"
+  ],
+  "rules": {
+    // Import commom prettier rules
+    "prettier/prettier": [
+      "error",
+      {
+        "tabWidth": 2,
+        "printWidth": 120,
+        "useTabs": false,
+        "semi": true,
+        "bracketSpacing": true,
+        "singleQuote": true,
+        "trailingComma": "none",
+        "arrowParens": "always"
+      }
+    ],
+    // Typescript Rules
+    "@typescript-eslint/camelcase": "off",
+    "@typescript-eslint/no-inferrable-types": "off",
+    "@typescript-eslint/explicit-function-return-type": ["warn", {
+      "allowExpressions": true,
+      "allowTypedFunctionExpressions": true,
+      "allowHigherOrderFunctions": true
+    }]
+  },
+  "overrides": [
+    {
+      "files": ["*.saga.ts"],
+      "rules": {
+        "@typescript-eslint/explicit-function-return-type": "off"
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1725,6 +1725,16 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
+    "@types/prosemirror-inputrules": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/prosemirror-inputrules/-/prosemirror-inputrules-1.0.2.tgz",
+      "integrity": "sha512-bKFneQUPnkZmzCJ1uoitpKH6PFW0hc4q55NsC7mFUCvX0eZl0GRKxyfV47jkJbsbyUQoO/QFv0WwLDz2bo15sA==",
+      "dev": true,
+      "requires": {
+        "@types/prosemirror-model": "*",
+        "@types/prosemirror-state": "*"
+      }
+    },
     "@types/prosemirror-model": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@types/prosemirror-model/-/prosemirror-model-1.7.2.tgz",
@@ -5111,6 +5121,23 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "dev": true
+        }
+      }
+    },
     "eslint-config-react-app": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-5.2.1.tgz",
@@ -5386,6 +5413,15 @@
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz",
+      "integrity": "sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-react": {
@@ -5798,6 +5834,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
       "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
     },
     "fast-glob": {
       "version": "2.2.7",
@@ -11351,6 +11393,21 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
+    "prettier": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
+      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-bytes": {
       "version": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -25,13 +25,11 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
-    "test:coverage": "react-scripts test --coverage --watchAll=true",
+    "test": "react-scripts test --coverage --watchAll=true",
+    "test:ci": "react-scripts test --coverage --ci",
     "eject": "react-scripts eject",
-    "lint": "eslint "
-  },
-  "eslintConfig": {
-    "extends": "react-app"
+    "lint": "eslint --fix src/**/*.ts src/**/*.tsx",
+    "lint:ci": "eslint src/**/*.ts src/**/*.tsx"
   },
   "browserslist": {
     "production": [
@@ -50,6 +48,7 @@
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^24.9.1",
     "@types/node": "^12.12.32",
+    "@types/prosemirror-inputrules": "^1.0.2",
     "@types/prosemirror-model": "^1.7.2",
     "@types/prosemirror-schema-list": "^1.0.1",
     "@types/prosemirror-state": "^1.2.3",
@@ -62,6 +61,9 @@
     "@types/redux-saga": "^0.10.5",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
+    "eslint-config-prettier": "^6.10.1",
+    "eslint-plugin-prettier": "^3.1.3",
+    "prettier": "2.0.4",
     "prosemirror-menu": "^1.1.4",
     "react-remock": "^0.8.1",
     "react-test-renderer": "^16.13.1",

--- a/src/app/actions/init.actions.ts
+++ b/src/app/actions/init.actions.ts
@@ -1,3 +1,3 @@
-import {createAction} from "../utils/action.utils";
+import { createAction } from '../utils/action.utils';
 
 export const initApplication = createAction<void>('INIT_LIBERO');

--- a/src/app/actions/manuscript.actions.ts
+++ b/src/app/actions/manuscript.actions.ts
@@ -1,6 +1,6 @@
-import {Manuscript} from '../models/manuscript';
-import {createAction, createAsyncAction, ofActionType} from '../utils/action.utils';
-import {Transaction} from "prosemirror-state";
+import { Manuscript } from '../models/manuscript';
+import { createAction, createAsyncAction, ofActionType } from '../utils/action.utils';
+import { Transaction } from 'prosemirror-state';
 
 export const loadManuscriptAction = createAsyncAction<string, Manuscript>('LOAD_MANUSCRIPT');
 export const updateTitleAction = createAction<Transaction>('SET_TITLE');
@@ -8,7 +8,8 @@ export const updateTitleAction = createAction<Transaction>('SET_TITLE');
 export const undoAction = createAction<void>('UNDO');
 export const redoAction = createAction<void>('REDO');
 
-export type ActionType = ofActionType<typeof loadManuscriptAction>
+export type ActionType =
+  | ofActionType<typeof loadManuscriptAction>
   | ofActionType<typeof undoAction>
   | ofActionType<typeof redoAction>
   | ofActionType<typeof updateTitleAction>;

--- a/src/app/api/__tests__/manuscript.api.test.ts
+++ b/src/app/api/__tests__/manuscript.api.test.ts
@@ -1,13 +1,12 @@
 import axios from 'axios';
-import {getManuscriptContent} from "../manuscript.api";
-import {EditorState} from "prosemirror-state";
+import { getManuscriptContent } from '../manuscript.api';
+import { EditorState } from 'prosemirror-state';
 
 jest.mock('axios');
 
 describe('manuscript API', () => {
-
   beforeEach(() => {
-    (axios.get as jest.Mock).mockResolvedValue(Promise.resolve({data: ''}));
+    (axios.get as jest.Mock).mockResolvedValue(Promise.resolve({ data: '' }));
   });
 
   it('loads manuscript data', async () => {
@@ -19,5 +18,4 @@ describe('manuscript API', () => {
 
     expect(axios.get).toHaveBeenCalledWith('/manuscripts/SOME_ID/manuscript.xml');
   });
-
 });

--- a/src/app/api/manuscript.api.ts
+++ b/src/app/api/manuscript.api.ts
@@ -1,14 +1,14 @@
 import axios from 'axios';
-import {Manuscript} from "../models/manuscript";
-import {createTitleState} from "../models/manuscript-state.factory";
+import { Manuscript } from '../models/manuscript';
+import { createTitleState } from '../models/manuscript-state.factory';
 
-const manuscriptUrl = (id: string) => `/manuscripts/${id}/manuscript.xml`;
+const manuscriptUrl = (id: string): string => `/manuscripts/${id}/manuscript.xml`;
 
 export async function getManuscriptContent(id: string): Promise<Manuscript> {
   const { data } = await axios.get<string>(manuscriptUrl(id));
 
   const parser = new DOMParser();
-  const doc =  parser.parseFromString(data, 'text/xml');
+  const doc = parser.parseFromString(data, 'text/xml');
   const title = doc.querySelector('title-group article-title');
 
   return {

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,29 +1,23 @@
 import React from 'react';
 
-import {
-  BrowserRouter as Router,
-  Switch,
-  Route
-} from "react-router-dom";
-import {Provider} from 'react-redux';
-import {store} from './store';
+import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { store } from './store';
 import './app.scss';
-import {ManuscriptContainer} from "./containers/manuscript";
+import { ManuscriptContainer } from './containers/manuscript';
 
-function App() {
+export const App: React.FC = () => {
   return (
     <Provider store={store}>
       <Router>
-          <div className='app-container'>
-            <Switch>
-              <Route path="/">
-                <ManuscriptContainer />
-              </Route>
-            </Switch>
-          </div>
+        <div className="app-container">
+          <Switch>
+            <Route path="/">
+              <ManuscriptContainer />
+            </Route>
+          </Switch>
+        </div>
       </Router>
     </Provider>
   );
-}
-
-export default App;
+};

--- a/src/app/components/rich-text-editor/schema-jats.ts
+++ b/src/app/components/rich-text-editor/schema-jats.ts
@@ -1,4 +1,5 @@
-import {DOMOutputSpec, Schema, SchemaSpec} from 'prosemirror-model';
+/* eslint-disable */
+import { DOMOutputSpec, Schema, SchemaSpec } from 'prosemirror-model';
 
 const pDOM = ['p', 0] as DOMOutputSpec,
   hrDOM = ['hr'] as DOMOutputSpec,
@@ -135,7 +136,7 @@ export const nodes = {
       }
     ],
     toDOM(node) {
-      let { src, alt, title } = node.attrs;
+      const { src, alt, title } = node.attrs;
       return ['img', { src, alt, title }] as DOMOutputSpec;
     }
   },
@@ -171,7 +172,7 @@ export const nodes = {
       }
     ],
     toDOM(node) {
-      let { href } = node.attrs;
+      const { href } = node.attrs;
       return ['a', { href }, 0] as DOMOutputSpec;
     }
   },
@@ -197,7 +198,7 @@ export const nodes = {
       }
     ],
     toDOM(node) {
-      let { href } = node.attrs;
+      const { href } = node.attrs;
       return ['a', { href }, 0] as DOMOutputSpec;
     }
   },
@@ -281,7 +282,7 @@ export const nodes = {
       }
     ],
     toDOM(node) {
-      let { src } = node.attrs;
+      const { src } = node.attrs;
       return ['img', { src }] as DOMOutputSpec;
     }
   },
@@ -323,7 +324,7 @@ export const marks = {
       }
     ],
     toDOM(node) {
-      let { href, title } = node.attrs;
+      const { href, title } = node.attrs;
       return ['a', { href, title }, 0] as DOMOutputSpec;
     }
   },
@@ -375,3 +376,4 @@ export const marks = {
 type NodesType = keyof typeof nodes;
 type MarksType = keyof typeof marks;
 export const schema = new Schema<NodesType, MarksType>({ nodes, marks } as SchemaSpec<NodesType, MarksType>);
+/* eslint-enable */

--- a/src/app/models/config/marks.ts
+++ b/src/app/models/config/marks.ts
@@ -1,21 +1,23 @@
+import { DOMOutputSpecArray } from 'prosemirror-model';
+
 export const marks = {
   sub: {
     parseDOM: [{ tag: 'sub' }],
-    toDOM() {
+    toDOM(): DOMOutputSpecArray {
       return ['sub', 0];
     }
   },
 
   sup: {
     parseDOM: [{ tag: 'sup' }],
-    toDOM() {
+    toDOM(): DOMOutputSpecArray {
       return ['sup', 0];
     }
   },
 
   em: {
     parseDOM: [{ tag: 'italic' }],
-    toDOM() {
+    toDOM(): DOMOutputSpecArray {
       return ['em', 0];
     }
   }

--- a/src/app/models/config/nodes.ts
+++ b/src/app/models/config/nodes.ts
@@ -1,3 +1,5 @@
+import { DOMOutputSpecArray } from 'prosemirror-model';
+
 export const nodes = {
   doc: {
     content: 'block'
@@ -6,9 +8,9 @@ export const nodes = {
   'article-title': {
     group: 'block',
     content: 'inline*',
-    parseDom: [{ tag: 'div', attrs: {'data-tag': 'article-title'}}],
-    toDOM(node) {
-      return ['div', {'data-tag': 'article-title', class: 'article-title'}, 0]
+    parseDom: [{ tag: 'div', attrs: { 'data-tag': 'article-title' } }],
+    toDOM(node): DOMOutputSpecArray {
+      return ['div', { 'data-tag': 'article-title', class: 'article-title' }, 0];
     }
   },
 

--- a/src/app/models/config/title.config.ts
+++ b/src/app/models/config/title.config.ts
@@ -1,3 +1,3 @@
 export const marks = ['em', 'sub', 'sup'];
 export const nodes = ['doc', 'article-title', 'text'];
-export const topNode = 'doc'
+export const topNode = 'doc';

--- a/src/app/models/manuscript-state.factory.ts
+++ b/src/app/models/manuscript-state.factory.ts
@@ -1,34 +1,30 @@
-import {DOMParser as ProseMirrorDOMParser, Schema, SchemaSpec} from "prosemirror-model";
-import {EditorState} from "prosemirror-state";
-import {pick} from 'lodash';
-import {gapCursor} from "prosemirror-gapcursor"
-import {dropCursor} from "prosemirror-dropcursor"
+import { DOMParser as ProseMirrorDOMParser, Schema, SchemaSpec } from 'prosemirror-model';
+import { EditorState } from 'prosemirror-state';
+import { pick } from 'lodash';
+import { gapCursor } from 'prosemirror-gapcursor';
+import { dropCursor } from 'prosemirror-dropcursor';
 
 import * as titleConfig from './config/title.config';
-import {nodes} from "./config/nodes";
-import {marks} from "./config/marks";
-import {buildInputRules} from "./plugins/input-rules";
+import { nodes } from './config/nodes';
+import { marks } from './config/marks';
+import { buildInputRules } from './plugins/input-rules';
 
-export function createTitleState(content: Node) {
+export function createTitleState(content: Node): EditorState {
   const docSchema = makeSchemaFromConfig(titleConfig.topNode, titleConfig.nodes, titleConfig.marks);
 
-  const xmlContentDocument = document.implementation.createDocument('', '', null)
-  if(content) {
+  const xmlContentDocument = document.implementation.createDocument('', '', null);
+  if (content) {
     xmlContentDocument.appendChild(content);
   }
 
   return EditorState.create({
     doc: ProseMirrorDOMParser.fromSchema(docSchema).parse(xmlContentDocument),
     schema: docSchema,
-    plugins: [
-      buildInputRules(docSchema),
-      gapCursor(),
-      dropCursor()
-    ]
+    plugins: [buildInputRules(), gapCursor(), dropCursor()]
   });
 }
 
-function makeSchemaFromConfig(topNode: string, nodeNames: string[], markNames: string[]) {
+function makeSchemaFromConfig(topNode: string, nodeNames: string[], markNames: string[]): Schema {
   const filteredNodes = pick(nodes, nodeNames);
   const filteredMarks = pick(marks, markNames);
   return new Schema({

--- a/src/app/models/manuscript.ts
+++ b/src/app/models/manuscript.ts
@@ -1,9 +1,9 @@
-import {EditorState, Transaction} from "prosemirror-state";
+import { EditorState, Transaction } from 'prosemirror-state';
 
 export type Manuscript = {
   title: EditorState;
-}
+};
 
 export type ManuscriptDiff = {
-  [K in keyof Manuscript]?: ( Manuscript[K] extends EditorState ? Transaction : Manuscript[K] ) | undefined;
-}
+  [K in keyof Manuscript]?: (Manuscript[K] extends EditorState ? Transaction : Manuscript[K]) | undefined;
+};

--- a/src/app/models/plugins/input-rules.ts
+++ b/src/app/models/plugins/input-rules.ts
@@ -1,6 +1,7 @@
-import {inputRules, smartQuotes, emDash, ellipsis} from "prosemirror-inputrules"
+import { inputRules, smartQuotes, emDash, ellipsis } from 'prosemirror-inputrules';
+import { Plugin } from 'prosemirror-state';
 
-export function buildInputRules(schema) {
-  let rules = smartQuotes.concat(ellipsis, emDash);
-  return inputRules({rules});
+export function buildInputRules(): Plugin {
+  const rules = smartQuotes.concat(ellipsis, emDash);
+  return inputRules({ rules });
 }

--- a/src/app/reducers/__tests__/manuscript-editor.reducer.spec.ts
+++ b/src/app/reducers/__tests__/manuscript-editor.reducer.spec.ts
@@ -1,15 +1,15 @@
-import {EditorState} from 'prosemirror-state';
-import {cloneDeep} from 'lodash'
+import { EditorState } from 'prosemirror-state';
+import { cloneDeep } from 'lodash';
 import * as manuscriptActions from '../../actions/manuscript.actions';
-import {manuscriptEditorReducer} from '../manuscript-editor.reducer';
-import {getInitialHistory} from '../../utils/state.utils';
-import {redoChange, undoChange, updateManuscriptState} from '../../utils/history.utils';
+import { manuscriptEditorReducer } from '../manuscript-editor.reducer';
+import { getInitialHistory } from '../../utils/state.utils';
+import { redoChange, undoChange, updateManuscriptState } from '../../utils/history.utils';
 
 jest.mock('../../utils/history.utils');
 
 describe('manuscript editor reducer', () => {
   it('should update title', () => {
-    const state = getInitialHistory({title: undefined});
+    const state = getInitialHistory({ title: undefined });
     const updatedState = cloneDeep(state);
     updatedState.present.title = new EditorState();
     (updateManuscriptState as jest.Mock).mockReturnValueOnce(updatedState);
@@ -19,9 +19,8 @@ describe('manuscript editor reducer', () => {
   });
 
   it('should undo last changes', () => {
-
-    const state = getInitialHistory({title: new EditorState()});
-    state.past.push({title: undefined});
+    const state = getInitialHistory({ title: new EditorState() });
+    state.past.push({ title: undefined });
 
     const undoneState = cloneDeep(state);
     undoneState.past = [];
@@ -31,9 +30,8 @@ describe('manuscript editor reducer', () => {
   });
 
   it('should redo undone last changes', () => {
-
-    const state = getInitialHistory({title: new EditorState()});
-    state.future.push({title: undefined});
+    const state = getInitialHistory({ title: new EditorState() });
+    state.future.push({ title: undefined });
 
     const redoneState = cloneDeep(state);
     redoneState.future = [];
@@ -41,4 +39,4 @@ describe('manuscript editor reducer', () => {
 
     expect(manuscriptEditorReducer(state, manuscriptActions.redoAction())).toBe(redoneState);
   });
-})
+});

--- a/src/app/reducers/__tests__/manuscript.reducer.spec.ts
+++ b/src/app/reducers/__tests__/manuscript.reducer.spec.ts
@@ -1,11 +1,9 @@
-
-import {getInitialHistory, getInitialLoadableState} from "../../utils/state.utils";
+import { getInitialHistory, getInitialLoadableState } from '../../utils/state.utils';
 import * as manuscriptActions from '../../actions/manuscript.actions';
-import {manuscriptReducer} from "../manuscript.reducer";
-import {EditorState} from "prosemirror-state";
+import { manuscriptReducer } from '../manuscript.reducer';
+import { EditorState } from 'prosemirror-state';
 
 describe('manuscript reducer', () => {
-
   it('should set state to loading', () => {
     const state = getInitialLoadableState();
 
@@ -16,7 +14,7 @@ describe('manuscript reducer', () => {
 
   it('should set data on state', () => {
     const state = getInitialLoadableState();
-    const data = {title: new EditorState()};
+    const data = { title: new EditorState() };
 
     expect(state.data).toBeFalsy();
     const newState = manuscriptReducer(state, manuscriptActions.loadManuscriptAction.success(data));
@@ -31,4 +29,4 @@ describe('manuscript reducer', () => {
     const newState = manuscriptReducer(state, manuscriptActions.loadManuscriptAction.error(error));
     expect(newState.error).toBe(error);
   });
-})
+});

--- a/src/app/reducers/manuscript-editor.reducer.ts
+++ b/src/app/reducers/manuscript-editor.reducer.ts
@@ -1,16 +1,19 @@
-import * as manuscriptActions from "../actions/manuscript.actions";
-import {ManuscriptHistory} from "../utils/state.utils";
-import {Transaction} from "prosemirror-state";
-import {redoChange, undoChange, updateManuscriptState} from "../utils/history.utils";
+import * as manuscriptActions from '../actions/manuscript.actions';
+import { ManuscriptHistory } from '../utils/state.utils';
+import { Transaction } from 'prosemirror-state';
+import { redoChange, undoChange, updateManuscriptState } from '../utils/history.utils';
 
-export function manuscriptEditorReducer(state: ManuscriptHistory | undefined, action: manuscriptActions.ActionType): ManuscriptHistory {
+export function manuscriptEditorReducer(
+  state: ManuscriptHistory | undefined,
+  action: manuscriptActions.ActionType
+): ManuscriptHistory {
   if (!state) {
     return state;
   }
 
-  switch(action.type) {
+  switch (action.type) {
     case manuscriptActions.updateTitleAction.type:
-      return updateManuscriptState(state, 'title', action.payload as Transaction)
+      return updateManuscriptState(state, 'title', action.payload as Transaction);
     case manuscriptActions.undoAction.type:
       return undoChange(state);
     case manuscriptActions.redoAction.type:

--- a/src/app/reducers/manuscript.reducer.ts
+++ b/src/app/reducers/manuscript.reducer.ts
@@ -1,4 +1,4 @@
-import {Manuscript} from '../models/manuscript';
+import { Manuscript } from '../models/manuscript';
 import * as manuscriptActions from '../actions/manuscript.actions';
 import {
   getInitialHistory,
@@ -7,15 +7,16 @@ import {
   getLoadableStateProgress,
   getLoadableStateSuccess
 } from '../utils/state.utils';
-import {
-  manuscriptEditorReducer,
-} from './manuscript-editor.reducer';
-import {ManuscriptHistoryState} from "../store";
+import { manuscriptEditorReducer } from './manuscript-editor.reducer';
+import { ManuscriptHistoryState } from '../store';
 
 const initialState = getInitialLoadableState() as ManuscriptHistoryState;
 
-export function manuscriptReducer(state: ManuscriptHistoryState = initialState, action: manuscriptActions.ActionType): ManuscriptHistoryState {
-  switch(action.type) {
+export function manuscriptReducer(
+  state: ManuscriptHistoryState = initialState,
+  action: manuscriptActions.ActionType
+): ManuscriptHistoryState {
+  switch (action.type) {
     case manuscriptActions.loadManuscriptAction.request.type:
       return {
         ...state,
@@ -24,7 +25,7 @@ export function manuscriptReducer(state: ManuscriptHistoryState = initialState, 
     case manuscriptActions.loadManuscriptAction.success.type:
       return {
         ...state,
-        ...getLoadableStateSuccess(getInitialHistory(action.payload  as Manuscript))
+        ...getLoadableStateSuccess(getInitialHistory(action.payload as Manuscript))
       };
 
     case manuscriptActions.loadManuscriptAction.error.type:

--- a/src/app/saga/__tests__/manuscript.saga.spec.ts
+++ b/src/app/saga/__tests__/manuscript.saga.spec.ts
@@ -1,12 +1,12 @@
-import {loadManuscriptSaga} from "../manuscript.saga";
-import {loadManuscriptAction} from "../../actions/manuscript.actions";
-import {put} from 'redux-saga/effects';
-import {EditorState} from "prosemirror-state";
-import {Manuscript} from "../../models/manuscript";
+import { loadManuscriptSaga } from '../manuscript.saga';
+import { loadManuscriptAction } from '../../actions/manuscript.actions';
+import { put } from 'redux-saga/effects';
+import { EditorState } from 'prosemirror-state';
+import { Manuscript } from '../../models/manuscript';
 
 describe('manuscript saga', () => {
   it('should load data', () => {
-    const response = {title: new EditorState()} as Manuscript;
+    const response = { title: new EditorState() } as Manuscript;
     const saga = loadManuscriptSaga(loadManuscriptAction.request('SOME_ID'));
 
     saga.next();
@@ -14,4 +14,4 @@ describe('manuscript saga', () => {
 
     expect(sagaResult).toEqual(put(loadManuscriptAction.success(response)));
   });
-})
+});

--- a/src/app/saga/manuscript.saga.ts
+++ b/src/app/saga/manuscript.saga.ts
@@ -1,8 +1,8 @@
-import {all, takeLatest, call, put} from 'redux-saga/effects';
+import { all, takeLatest, call, put } from 'redux-saga/effects';
 import * as manuscriptActions from '../actions/manuscript.actions';
 import * as initActions from '../actions/init.actions';
-import {Action} from "../utils/action.utils";
-import {getManuscriptContent} from "../api/manuscript.api";
+import { Action } from '../utils/action.utils';
+import { getManuscriptContent } from '../api/manuscript.api';
 
 export function* loadManuscriptSaga(action: Action<string>) {
   const id = action.payload || '00104';
@@ -14,9 +14,9 @@ export function* loadManuscriptSaga(action: Action<string>) {
   }
 }
 
-export default function*() {
+export default function* () {
   yield all([
     takeLatest(manuscriptActions.loadManuscriptAction.request.type, loadManuscriptSaga),
-    takeLatest(initActions.initApplication.type, loadManuscriptSaga),
+    takeLatest(initActions.initApplication.type, loadManuscriptSaga)
   ]);
 }

--- a/src/app/selectors/__tests__/manuscript.selectors.spec.ts
+++ b/src/app/selectors/__tests__/manuscript.selectors.spec.ts
@@ -1,13 +1,13 @@
-import {getInitialHistory, getInitialLoadableState} from "../../utils/state.utils";
+import { getInitialHistory, getInitialLoadableState } from '../../utils/state.utils';
 import {
   canRedoChanges,
   canUndoChanges,
   getManuscriptData,
   getManuscriptTitle,
   isManuscriptLoaded
-} from "../manuscript.selectors";
-import {cloneDeep} from 'lodash';
-import {EditorState} from "prosemirror-state";
+} from '../manuscript.selectors';
+import { cloneDeep } from 'lodash';
+import { EditorState } from 'prosemirror-state';
 
 describe('manuscript selectors', () => {
   let state;
@@ -15,7 +15,7 @@ describe('manuscript selectors', () => {
   beforeEach(() => {
     state = {
       manuscript: getInitialLoadableState()
-    }
+    };
   });
 
   it('gets manuscript data', () => {
@@ -37,15 +37,14 @@ describe('manuscript selectors', () => {
   it('checks if changes can be undone', () => {
     state.manuscript.data = getInitialHistory({ title: new EditorState() });
 
-    state.manuscript.data.past.push({title: undefined});
+    state.manuscript.data.past.push({ title: undefined });
     expect(canUndoChanges(state)).toBeTruthy();
   });
 
   it('checks if changes can be redone', () => {
     state.manuscript.data = getInitialHistory({ title: new EditorState() });
 
-    state.manuscript.data.future.push({title: undefined});
+    state.manuscript.data.future.push({ title: undefined });
     expect(canRedoChanges(state)).toBeTruthy();
   });
-
-})
+});

--- a/src/app/selectors/manuscript.selectors.ts
+++ b/src/app/selectors/manuscript.selectors.ts
@@ -1,32 +1,17 @@
 import { createSelector } from 'reselect';
-import {ApplicationState} from "../store";
+import { ApplicationState, ManuscriptHistoryState } from '../store';
 import { get } from 'lodash';
 
-const getManuscriptState = (state: ApplicationState) => {
+const getManuscriptState = (state: ApplicationState): ManuscriptHistoryState => {
   return state.manuscript;
 };
 
-export const getManuscriptData = createSelector(
-  getManuscriptState,
-  state => get(state, 'data')
-);
+export const getManuscriptData = createSelector(getManuscriptState, (state) => get(state, 'data'));
 
-export const isManuscriptLoaded = createSelector(
-  getManuscriptData,
-  data => Boolean(data)
-);
+export const isManuscriptLoaded = createSelector(getManuscriptData, (data) => Boolean(data));
 
-export const getManuscriptTitle = createSelector(
-  getManuscriptData,
-  data => get(data, 'present.title')
-);
+export const getManuscriptTitle = createSelector(getManuscriptData, (data) => get(data, 'present.title'));
 
-export const canUndoChanges = createSelector(
-  getManuscriptData,
-  data => get(data, 'past.length') > 0
-);
+export const canUndoChanges = createSelector(getManuscriptData, (data) => get(data, 'past.length') > 0);
 
-export const canRedoChanges = createSelector(
-  getManuscriptData,
-  data => get(data, 'future.length') > 0
-);
+export const canRedoChanges = createSelector(getManuscriptData, (data) => get(data, 'future.length') > 0);

--- a/src/app/store/index.ts
+++ b/src/app/store/index.ts
@@ -2,20 +2,22 @@ import { combineReducers, createStore, applyMiddleware } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import { rootSaga } from '../saga';
-import {manuscriptReducer} from '../reducers/manuscript.reducer';
-import {LoadableState, ManuscriptHistory} from "../utils/state.utils";
+import { manuscriptReducer } from '../reducers/manuscript.reducer';
+import { LoadableState, ManuscriptHistory } from '../utils/state.utils';
 
 const sagaMiddleware = createSagaMiddleware();
 
-
-export interface ManuscriptHistoryState extends LoadableState<ManuscriptHistory> {}
+export type ManuscriptHistoryState = LoadableState<ManuscriptHistory>;
 
 export interface ApplicationState {
   manuscript: ManuscriptHistoryState;
 }
 
-export const store = createStore(combineReducers({
-  manuscript: manuscriptReducer
-}), composeWithDevTools(applyMiddleware(sagaMiddleware)));
+export const store = createStore(
+  combineReducers({
+    manuscript: manuscriptReducer
+  }),
+  composeWithDevTools(applyMiddleware(sagaMiddleware))
+);
 
 sagaMiddleware.run(rootSaga);

--- a/src/app/utils/__tests__/history.utils.spec.ts
+++ b/src/app/utils/__tests__/history.utils.spec.ts
@@ -1,16 +1,16 @@
-import {getInitialHistory, ManuscriptHistory} from "../state.utils";
-import {redoChange, undoChange, updateManuscriptState} from "../history.utils";
-import {Manuscript} from "../../models/manuscript";
-import {EditorState, Transaction} from "prosemirror-state";
+import { getInitialHistory, ManuscriptHistory } from '../state.utils';
+import { redoChange, undoChange, updateManuscriptState } from '../history.utils';
+import { Manuscript } from '../../models/manuscript';
+import { EditorState, Transaction } from 'prosemirror-state';
 
 describe('history utils', () => {
   it('updates manuscript state', () => {
     const editorState = mockEditorState();
-    const initialHistory = getInitialHistory({title: editorState} as Manuscript) as ManuscriptHistory;
-    const tx = {...editorState.tr, docChanged: true} as Transaction;
+    const initialHistory = getInitialHistory({ title: editorState } as Manuscript) as ManuscriptHistory;
+    const tx = { ...editorState.tr, docChanged: true } as Transaction;
 
     const newState = updateManuscriptState(initialHistory, 'title', tx);
-    expect(newState.past).toContainEqual({title: tx});
+    expect(newState.past).toContainEqual({ title: tx });
     expect(newState.present).not.toBe(initialHistory.present);
     expect(newState.present.title).not.toBe(editorState);
     expect(newState.future).toEqual([]);
@@ -18,7 +18,7 @@ describe('history utils', () => {
 
   it('updates present editor state but not affect history when docChanged is false', () => {
     const editorState = mockEditorState();
-    const initialHistory = getInitialHistory({title: editorState} as Manuscript) as ManuscriptHistory;
+    const initialHistory = getInitialHistory({ title: editorState } as Manuscript) as ManuscriptHistory;
     const tx = editorState.tr;
 
     const newState = updateManuscriptState(initialHistory, 'title', tx);
@@ -31,34 +31,34 @@ describe('history utils', () => {
 
   it('reverts changes', () => {
     const editorState = mockEditorState();
-    const state = getInitialHistory({title: editorState} as Manuscript) as ManuscriptHistory;
-    const tx = {...editorState.tr, docChanged: true} as Transaction;
-    state.past = [{title: tx}];
+    const state = getInitialHistory({ title: editorState } as Manuscript) as ManuscriptHistory;
+    const tx = { ...editorState.tr, docChanged: true } as Transaction;
+    state.past = [{ title: tx }];
 
-    const revertedState = undoChange(state)
+    const revertedState = undoChange(state);
 
     expect(revertedState.past).toEqual([]);
     expect(revertedState.present).not.toBe(state.present);
     expect(revertedState.present.title).not.toBe(editorState);
-    expect(revertedState.future).toEqual([{title: tx}]);
+    expect(revertedState.future).toEqual([{ title: tx }]);
   });
 
   it('roll on changes', () => {
     const editorState = mockEditorState();
-    const state = getInitialHistory({title: editorState} as Manuscript) as ManuscriptHistory;
-    const tx = {...editorState.tr, docChanged: true} as Transaction;
-    state.future = [{title: tx}];
+    const state = getInitialHistory({ title: editorState } as Manuscript) as ManuscriptHistory;
+    const tx = { ...editorState.tr, docChanged: true } as Transaction;
+    state.future = [{ title: tx }];
 
-    const rolledOnState = redoChange(state)
+    const rolledOnState = redoChange(state);
 
-    expect(rolledOnState.past).toEqual([{title: tx}]);
+    expect(rolledOnState.past).toEqual([{ title: tx }]);
     expect(rolledOnState.present).not.toBe(state.present);
     expect(rolledOnState.present.title).not.toBe(editorState);
     expect(rolledOnState.future).toEqual([]);
   });
 });
 
-function mockEditorState() {
+function mockEditorState(): EditorState {
   const state = new EditorState();
   jest.spyOn(state, 'apply').mockImplementation(() => mockEditorState());
   return state;

--- a/src/app/utils/action.utils.ts
+++ b/src/app/utils/action.utils.ts
@@ -3,7 +3,7 @@ export interface Action<T> {
   payload: T;
 }
 
-export type ActionFactory<T> = ( (payload :T) => Action<T> ) & {type: string};
+export type ActionFactory<T> = ((payload: T) => Action<T>) & { type: string };
 
 export interface AsyncAction<R, T> {
   request: ActionFactory<R>;
@@ -13,12 +13,12 @@ export interface AsyncAction<R, T> {
 
 export type ofActionType<A> = A extends AsyncAction<infer R, infer T>
   ? Action<R> | Action<T> | Action<Error>
-  : A extends ((...args: any[]) => any)
-    ? ReturnType<A>
-    : never;
+  : A extends (...args: unknown[]) => unknown
+  ? ReturnType<A>
+  : never;
 
 export function createAction<T>(type: string): ActionFactory<T> {
-  const actionFn = (payload: T): Action<T> => ({type, payload});
+  const actionFn = (payload: T): Action<T> => ({ type, payload });
   actionFn.type = type;
   return actionFn as ActionFactory<T>;
 }
@@ -30,5 +30,3 @@ export function createAsyncAction<R, T>(type: string): AsyncAction<R, T> {
     error: createAction<Error>(type + '_ERROR')
   } as AsyncAction<R, T>;
 }
-
-

--- a/src/app/utils/history.utils.ts
+++ b/src/app/utils/history.utils.ts
@@ -1,14 +1,18 @@
-import {Manuscript, ManuscriptDiff} from "../models/manuscript";
-import {ManuscriptHistory} from "./state.utils";
-import {Transaction} from "prosemirror-state";
+import { Manuscript, ManuscriptDiff } from '../models/manuscript';
+import { ManuscriptHistory } from './state.utils';
+import { Transaction } from 'prosemirror-state';
 
-export function updateManuscriptState(state: ManuscriptHistory, propName: string, transaction: Transaction): ManuscriptHistory {
-  const updatedManuscript = applyDiffToManuscript(state.present, {[propName]: transaction});
+export function updateManuscriptState(
+  state: ManuscriptHistory,
+  propName: string,
+  transaction: Transaction
+): ManuscriptHistory {
+  const updatedManuscript = applyDiffToManuscript(state.present, { [propName]: transaction });
 
   // only update history when document changes
-  if(transaction.docChanged) {
+  if (transaction.docChanged) {
     return {
-      past: [...state.past, {[propName]: transaction}],
+      past: [...state.past, { [propName]: transaction }],
       present: updatedManuscript,
       future: []
     } as ManuscriptHistory;
@@ -20,8 +24,8 @@ export function updateManuscriptState(state: ManuscriptHistory, propName: string
   }
 }
 
-export function undoChange(state: ManuscriptHistory) {
-  const past = [...state.past]
+export function undoChange(state: ManuscriptHistory): ManuscriptHistory {
+  const past = [...state.past];
   const diff = past.pop();
   const undoDiff = invertDiff(state.present, diff);
 
@@ -34,8 +38,8 @@ export function undoChange(state: ManuscriptHistory) {
   };
 }
 
-export function redoChange(state: ManuscriptHistory) {
-  const future = [...state.future]
+export function redoChange(state: ManuscriptHistory): ManuscriptHistory {
+  const future = [...state.future];
   const diff = future.shift();
 
   const updatedManuscript = applyDiffToManuscript(state.present, diff);
@@ -47,7 +51,7 @@ export function redoChange(state: ManuscriptHistory) {
   };
 }
 
-function invertDiff(manuscript: Manuscript, diff: ManuscriptDiff) {
+function invertDiff(manuscript: Manuscript, diff: ManuscriptDiff): ManuscriptDiff {
   return Object.keys(diff).reduce((acc, key) => {
     if (!diff[key]) {
       return acc;
@@ -56,19 +60,15 @@ function invertDiff(manuscript: Manuscript, diff: ManuscriptDiff) {
     const invertedSteps = diff[key].steps.map((step) => step.invert(diff[key].doc));
     const invertedTransaction = manuscript[key].tr;
 
-    invertedSteps.reverse().forEach(step => invertedTransaction.maybeStep(step));
+    invertedSteps.reverse().forEach((step) => invertedTransaction.maybeStep(step));
     acc[key] = invertedTransaction;
     return acc;
   }, {} as ManuscriptDiff);
 }
 
 function applyDiffToManuscript(manuscript: Manuscript, diff: ManuscriptDiff): Manuscript {
-  return Object.keys(manuscript)
-    .reduce((acc, propName) => {
-      acc[propName] = diff[propName] ? manuscript[propName].apply(diff[propName]) : manuscript[propName];
-      return acc;
-    }, {} as Manuscript)
-
+  return Object.keys(manuscript).reduce((acc, propName) => {
+    acc[propName] = diff[propName] ? manuscript[propName].apply(diff[propName]) : manuscript[propName];
+    return acc;
+  }, {} as Manuscript);
 }
-
-

--- a/src/app/utils/state.utils.ts
+++ b/src/app/utils/state.utils.ts
@@ -1,4 +1,4 @@
-import {Manuscript, ManuscriptDiff} from "../models/manuscript";
+import { Manuscript, ManuscriptDiff } from '../models/manuscript';
 
 export interface LoadableState<T> {
   data: T | undefined;
@@ -6,15 +6,15 @@ export interface LoadableState<T> {
   error: Error | undefined;
 }
 
-export function getInitialLoadableState() {
+export function getInitialLoadableState<T>(): LoadableState<T> {
   return {
     data: undefined,
     isLoading: false,
     error: undefined
-  }
+  };
 }
 
-export function getLoadableStateProgress() {
+export function getLoadableStateProgress<T>(): LoadableState<T> {
   return {
     data: undefined,
     isLoading: true,
@@ -22,7 +22,7 @@ export function getLoadableStateProgress() {
   };
 }
 
-export function getLoadableStateSuccess<T>(data: T) {
+export function getLoadableStateSuccess<T>(data: T): LoadableState<T> {
   return {
     data,
     isLoading: false,
@@ -30,7 +30,7 @@ export function getLoadableStateSuccess<T>(data: T) {
   };
 }
 
-export function getLoadableStateError<T>(error: Error) {
+export function getLoadableStateError<T>(error: Error): LoadableState<T> {
   console.log(error);
   return {
     data: undefined,
@@ -43,8 +43,8 @@ export interface ManuscriptHistory {
   past: ManuscriptDiff[];
   present: Manuscript;
   future: ManuscriptDiff[];
-};
+}
 
-export function getInitialHistory(present: Manuscript) {
-  return { past: [], present, future: []};
+export function getInitialHistory(present: Manuscript): ManuscriptHistory {
+  return { past: [], present, future: [] };
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.scss';
-import App from './app/app';
+import {App} from './app/app';
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });


### PR DESCRIPTION
saga files were excluded from explicit return type rule because there seems to be no reasonable agreement what should the return type of generators be in typescript. 