### PR TITLE
fix: missing accept header in request

### DIFF
--- a/src/app/api/__tests__/manuscript.api.test.ts
+++ b/src/app/api/__tests__/manuscript.api.test.ts
@@ -18,6 +18,6 @@ describe('manuscript API', () => {
       keywords: expect.any(Object)
     });
 
-    expect(axios.get).toHaveBeenCalledWith('/api/v1/articles/SOME_ID/');
+    expect(axios.get).toHaveBeenCalledWith('/api/v1/articles/SOME_ID/', { headers: { Accept: 'application/xml' } });
   });
 });

--- a/src/app/api/manuscript.api.ts
+++ b/src/app/api/manuscript.api.ts
@@ -7,7 +7,7 @@ const manuscriptUrl = (id: string): string => {
 };
 
 export async function getManuscriptContent(id: string): Promise<Manuscript> {
-  const { data } = await axios.get<string>(manuscriptUrl(id));
+  const { data } = await axios.get<string>(manuscriptUrl(id), { headers: { Accept: 'application/xml' } });
 
   const parser = new DOMParser();
   const doc = parser.parseFromString(data, 'text/xml');


### PR DESCRIPTION
Server responds with JSON by default unless the accept header is set, so have updated
the request to ask specifically for an xml response.