### PR TITLE
chore(ci): tag containers using new standard

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,14 +30,25 @@ jobs:
           npm run test:ci
         env:
           CI: true
-      - name: Publish
+      - name: Publish as 'unstable'
+        if: github.ref == 'refs/heads/master'
+        run: |
+          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+          docker build --no-cache -t -t $DOCKER_USERNAME/$REPO_NAME:unstable .
+          docker push $DOCKER_USERNAME/$REPO_NAME:unstable
+          .scripts/github/retag-and-push.sh $REPO_NAME $unstable
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Publish as 'stable'
         if: contains(github.ref, 'refs/tags/v')
         run: |
           docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-          docker build --no-cache -t $DOCKER_USERNAME/$REPO_NAME:${GITHUB_REF/refs\/tags\/v/} -t $DOCKER_USERNAME/$REPO_NAME:stable -t $DOCKER_USERNAME/$REPO_NAME:latest .
-          docker push $DOCKER_USERNAME/$REPO_NAME
+          docker build --no-cache -t -t $DOCKER_USERNAME/$REPO_NAME:stable .
+          docker push $DOCKER_USERNAME/$REPO_NAME:stable
+          .scripts/github/retag-and-push.sh $REPO_NAME $stable
         env:
-          CI: true
           REPO_NAME: ${{ github.event.repository.name }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".scripts"]
+	path = .scripts
+	url = https://github.com/libero/scripts


### PR DESCRIPTION
Updated the actions to now call the community script for tagging containers. This is
part of getting a GitOps workflow implemented for editor.