### PR TITLE
fix: publish steps should not run on forks

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           CI: true
       - name: Publish as 'unstable'
-        if: github.ref == 'refs/heads/master'
+        if: github.repository_owner == 'libero' && github.ref == 'refs/heads/master'
         run: |
           docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
           docker build --no-cache -t $DOCKER_USERNAME/$REPO_NAME:unstable .
@@ -44,7 +44,7 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       - name: Publish as 'stable'
-        if: contains(github.ref, 'refs/tags/v')
+        if: github.repository_owner == 'libero' &&  contains(github.ref, 'refs/tags/v')
         run: |
           docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
           docker build --no-cache -t $DOCKER_USERNAME/$REPO_NAME:stable .


### PR DESCRIPTION
The publish steps of the CD action kept trying to run on forks, and as such would
fail. These steps should only run on the 'libero' version, hence added some extra
checks to skip the offending steps on all forks.