### PR TITLE
feedback from designer and stakeholders

### DIFF
--- a/src/app/components/reference-citation-editor-popup/index.tsx
+++ b/src/app/components/reference-citation-editor-popup/index.tsx
@@ -68,11 +68,11 @@ export const ReferenceCitationEditorPopup: React.FC<ReferenceCitationEditorPopup
       setFilterValue(event.target['value']);
       setFilteredRefs(
         refs.filter((ref) => {
-          return getRefListItemText(ref).toLowerCase().indexOf(filterValue) >= 0;
+          return getRefListItemText(ref).toLowerCase().indexOf(filterValue) >= 0 || refId === ref.id;
         })
       );
     },
-    [refs, setFilterValue]
+    [refs, setFilterValue, refId]
   );
   const handleClick = useCallback(
     (event: SyntheticEvent) => {

--- a/src/app/components/rich-text-editor/__tests__/prosemirror-editor-view.spec.tsx
+++ b/src/app/components/rich-text-editor/__tests__/prosemirror-editor-view.spec.tsx
@@ -4,6 +4,8 @@ import { EditorState } from 'prosemirror-state';
 import { ProseMirrorEditorView } from 'app/components/rich-text-editor/prosemirror-editor-view';
 import { EditorView } from 'prosemirror-view';
 import { mount } from 'enzyme';
+import {createDummyEditorState} from "app/test-utils/reducer-test-helpers";
+import { DOMSerializer } from 'prosemirror-model';
 
 jest.mock('prosemirror-view');
 
@@ -23,7 +25,7 @@ describe('prosemirror view', () => {
   });
 
   it('should render', () => {
-    const sampleState = new EditorState();
+    const sampleState = createDummyEditorState();
     const onChangeHandler = jest.fn();
 
     const component = create(<ProseMirrorEditorView editorState={sampleState} onChange={onChangeHandler} />, {
@@ -32,12 +34,17 @@ describe('prosemirror view', () => {
     expect(component).toMatchSnapshot();
     expect(EditorView).toBeCalledWith(
       { props: { className: 'prosemirrorContainer' }, type: 'div' },
-      { state: sampleState, dispatchTransaction: expect.any(Function) }
+      {
+        state: sampleState,
+        clipboardSerializer: expect.any(DOMSerializer),
+        clipboardTextSerializer: expect.any(Function),
+        dispatchTransaction: expect.any(Function)
+      }
     );
   });
 
   it('should trigger onChange', () => {
-    const sampleState = new EditorState();
+    const sampleState = createDummyEditorState();
     const onChangeHandler = jest.fn();
 
     create(<ProseMirrorEditorView editorState={sampleState} onChange={onChangeHandler} />, { createNodeMock });
@@ -49,7 +56,7 @@ describe('prosemirror view', () => {
   });
 
   it('should update EditorView when props change', () => {
-    const sampleState = new EditorState();
+    const sampleState = createDummyEditorState();
     const onChangeHandler = jest.fn();
 
     const component = mount(<ProseMirrorEditorView editorState={sampleState} onChange={onChangeHandler} />);
@@ -59,7 +66,7 @@ describe('prosemirror view', () => {
   });
 
   it('should destroy EditorView when unmount', () => {
-    const sampleState = new EditorState();
+    const sampleState = createDummyEditorState();
     const onChangeHandler = jest.fn();
 
     const component = mount(<ProseMirrorEditorView editorState={sampleState} onChange={onChangeHandler} />);

--- a/src/app/containers/manuscript/styles.ts
+++ b/src/app/containers/manuscript/styles.ts
@@ -12,7 +12,7 @@ export const useManuscriptStyles = makeStyles((theme) => ({
     maxWidth: 700,
     boxSizing: 'border-box',
     width: '100%',
-    padding: theme.spacing(2),
+    padding: theme.spacing(5, 2),
     margin: '0 auto'
   },
   spacer: {

--- a/src/app/models/config/marks.ts
+++ b/src/app/models/config/marks.ts
@@ -16,7 +16,7 @@ export const marks = {
   },
 
   italic: {
-    parseDOM: [{ tag: 'italic' }],
+    parseDOM: [{ tag: 'italic' }, { tag: 'em' }],
     toDOM(): DOMOutputSpecArray {
       return ['em', 0];
     }

--- a/src/app/models/config/nodes.ts
+++ b/src/app/models/config/nodes.ts
@@ -1,3 +1,5 @@
+import { DOMOutputSpec } from 'prosemirror-model';
+
 function getTitleLevel(title: Element): number {
   let parent = title.parentNode;
   let level = 1;
@@ -120,7 +122,20 @@ export const nodes = {
         }
       }
     ],
-    toDOM(node) {
+    toClipboardDOM(node): DOMOutputSpec {
+      const refCitationDom = document.createElement('a');
+      refCitationDom.setAttribute('href', '#');
+      refCitationDom.setAttribute('data-cit-type', 'reference');
+      refCitationDom.setAttribute('data-ref-id', node.attrs.refId);
+      refCitationDom.setAttribute('data-ref-text', node.attrs.refText);
+      refCitationDom.classList.add('citation');
+      refCitationDom.innerHTML = `${node.attrs.refText}`;
+      return refCitationDom;
+    },
+    toClipboardText(node): string {
+      return node.attrs.refText;
+    },
+    toDOM(node): DOMOutputSpec {
       return [
         'a',
         {


### PR DESCRIPTION
- padding top and bottom set to 40px for article view
- filtering references in citation popup keeps the current option on the list
- paste without format fixed for reference citations (previously links text was dropped)
- italics copy and paste formatted fixed