### PR TITLE
refactor: store assets as tif in xml change

### DIFF
--- a/src/app/components/figure/figure-editor.tsx
+++ b/src/app/components/figure/figure-editor.tsx
@@ -110,7 +110,11 @@ export const FigureEditor = React.forwardRef((props: FigureEditorProps, ref) => 
           <img
             className={classes.image}
             alt="figure"
-            src={`/api/v1/articles/${manuscriptId}${figureNode.attrs.img.replace(/\.tiff?$/, '.jpeg')}`}
+            src={
+              figureNode.attrs.img
+                ? `/api/v1/articles/${manuscriptId}${figureNode.attrs.img.replace(/\.tiff?$/, '.jpeg')}`
+                : ''
+            }
           />
           <IconButton classes={{ root: classes.uploadImageCta }} onClick={handleUploadImageClick}>
             <AddPhotoAlternateIcon fontSize="small" />

--- a/src/app/components/figure/figure-editor.tsx
+++ b/src/app/components/figure/figure-editor.tsx
@@ -12,8 +12,9 @@ import { EditorView } from 'prosemirror-view';
 import { FigureLicensesList } from './figure-license-list';
 import { renderConfirmDialog } from 'app/components/prompt-dialog';
 import DragIcon from 'app/assets/drag-indicator-grey.svg';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { updateFigureImageAction } from 'app/actions/manuscript.actions';
+import { getManuscriptId } from 'app/selectors/manuscript-editor.selectors';
 
 /* Prosemirror relies heavily on the positioning of nodes in its internal state presentation.
   Given figure structure
@@ -50,6 +51,7 @@ interface FigureEditorProps {
 
 export const FigureEditor = React.forwardRef((props: FigureEditorProps, ref) => {
   const { onDelete, onAttributesChange } = props;
+  const manuscriptId = useSelector(getManuscriptId);
   const [figureNode, setFigureNode] = useState<ProsemirrorNode>(props.node);
   const [isConfirmShown, setConfirmShown] = useState<boolean>(false);
   const dispatch = useDispatch();
@@ -105,7 +107,11 @@ export const FigureEditor = React.forwardRef((props: FigureEditorProps, ref) => 
           onChange={handleLabelChange}
         />
         <div className={classes.imageContainer}>
-          <img className={classes.image} alt="figure" src={figureNode.attrs.img} />
+          <img
+            className={classes.image}
+            alt="figure"
+            src={`/api/v1/articles/${manuscriptId}${figureNode.attrs.img.replace(/\.tiff?$/, '.jpeg')}`}
+          />
           <IconButton classes={{ root: classes.uploadImageCta }} onClick={handleUploadImageClick}>
             <AddPhotoAlternateIcon fontSize="small" />
           </IconButton>

--- a/src/app/models/figure.ts
+++ b/src/app/models/figure.ts
@@ -50,7 +50,7 @@ export function getFigureImageUrlFromXml(el: Element): string {
 
 export function getFigureImageUrl(id: string, fileName: string): string {
   // FIXME: We should cope with bad image URLs better than this, perhaps by using a placeholder instead.
-  return fileName ? `/api/v1/articles/${id}/assets/${fileName.replace(/\.tiff?$/, '.jpeg')}` : '';
+  return fileName ? `/assets/${fileName}` : '';
 }
 
 function getLicenseType(el: Element): string {


### PR DESCRIPTION
Store the asset changes as .tif so that exported xml references tif not .jpeg. 

THIS WILL BREAK EXISTING CHANGES IN STAGING